### PR TITLE
Bring abort() to download

### DIFF
--- a/src/plugins/fileTransfer.js
+++ b/src/plugins/fileTransfer.js
@@ -21,6 +21,10 @@ angular.module('ngCordova.plugins.fileTransfer', [])
           q.notify(progress);
         };
 
+        q.promise.abort = function () {
+          ft.abort();
+        };
+
         ft.download(uri, filePath, q.resolve, q.reject, trustAllHosts, options);
         return q.promise;
       },


### PR DESCRIPTION
Sometimes we need a way to cancel (other than timeout).